### PR TITLE
fix: Enable -maes intrinsic to enable AES NI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(idaxex)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)
 
+# Enable AES NI intrinsic
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -maes")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes")
+
 include($ENV{IDASDK}/ida-cmake/common.cmake)
 
 set(LOADER_NAME    idaxex)


### PR DESCRIPTION
Without this change, building fails with

```
/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/wmmintrin.h: In function ‘ExCryptAesKey’:

/usr/lib/gcc/x86_64-pc-linux-gnu/14/include/wmmintrin.h:64:1: error: inlining failed in call to ‘always_inline’ ‘_mm_aesimc_si128’: target specific option mismatch
   64 | _mm_aesimc_si128 (__m128i __X)
      | ^~~~~~~~~~~~~~~~

```