### PR TITLE
Support latest ida-cmake

### DIFF
--- a/3rdparty/byte_order.hpp
+++ b/3rdparty/byte_order.hpp
@@ -23,6 +23,7 @@ namespace xe {
 #define XENIA_BASE_BYTE_SWAP_32 _byteswap_ulong
 #define XENIA_BASE_BYTE_SWAP_64 _byteswap_uint64
 #elif XE_PLATFORM_MAC
+#include <libkern/OSByteOrder.h>
 #define XENIA_BASE_BYTE_SWAP_16 OSSwapInt16
 #define XENIA_BASE_BYTE_SWAP_32 OSSwapInt32
 #define XENIA_BASE_BYTE_SWAP_64 OSSwapInt64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,10 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -maes")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes")
 
-include($ENV{IDASDK}/ida-cmake/common.cmake)
+include($ENV{IDASDK}/ida-cmake/bootstrap.cmake)
+find_package(idasdk REQUIRED)
 
-set(LOADER_NAME idaxex)
-set(LOADER_SOURCES
+ida_add_loader(idaxex SOURCES
   idaloader.cpp
   idaloader_xbe.cpp
   namegen.cpp
@@ -34,10 +34,19 @@ set(LOADER_SOURCES
   3rdparty/XbSymbolDatabase/src/OOVPADatabase/Xapi_OOVPA.c
   3rdparty/XbSymbolDatabase/src/OOVPADatabase/XGraphic_OOVPA.c
   3rdparty/XbSymbolDatabase/src/OOVPADatabase/XNet_OOVPA.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/XOnline_OOVPA.c
-)
-set(LOADER_INCLUDE_DIRECTORIES 3rdparty/excrypt/src 3rdparty/XbSymbolDatabase/include 3rdparty/XbSymbolDatabase/src/OOVPADatabase $ENV{IDASDK}/ldr/pe)
-add_compile_definitions(IDALDR=1)
+  3rdparty/XbSymbolDatabase/src/OOVPADatabase/XOnline_OOVPA.c)
 
-generate()
-disable_ida_warnings(idaxex)
+target_include_directories(idaxex PUBLIC
+  3rdparty/excrypt/src 
+  3rdparty/XbSymbolDatabase/include 
+  3rdparty/XbSymbolDatabase/src/OOVPADatabase 
+  $ENV{IDASDK}/ldr/pe)
+target_compile_definitions(idaxex PUBLIC IDALDR=1)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  target_compile_definitions(idaxex PUBLIC XE_PLATFORM_MAC=1)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(idaxex PUBLIC -Wno-non-pod-varargs)
+endif()


### PR DESCRIPTION
[ida-cmake](https://github.com/allthingsida/ida-cmake) seems to have been updated in a way that breaks backwards compatibility entirely. I've patched up `CMakeLists.txt` to use the new [functions](https://github.com/allthingsida/ida-cmake?tab=readme-ov-file#ida_add_loadername-).

Also a couple of changes for **macOS**/**Clang** targets specifically:
- Included `libkern/OSByteOrder.h` (declares `OSSwapInt**`) in `3rdparty/byte_order.hpp`
- Added the `-Wno-non-pod-varargs` flag for **Clang**, which suppresses a few errors about `be<T>` objects being passed as variadic arguments to `dbgmsg()` calls, which is evidently compiler-specific behaviour, but seems to work fine (IDA didn't crash for me when printing out messages containing those).