### PR TITLE
Update loader for IDA Pro 9.3

### DIFF
--- a/3rdparty/byte_order.hpp
+++ b/3rdparty/byte_order.hpp
@@ -23,6 +23,7 @@ namespace xe {
 #define XENIA_BASE_BYTE_SWAP_32 _byteswap_ulong
 #define XENIA_BASE_BYTE_SWAP_64 _byteswap_uint64
 #elif XE_PLATFORM_MAC
+#include <libkern/OSByteOrder.h>
 #define XENIA_BASE_BYTE_SWAP_16 OSSwapInt16
 #define XENIA_BASE_BYTE_SWAP_32 OSSwapInt32
 #define XENIA_BASE_BYTE_SWAP_64 OSSwapInt64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,39 +5,64 @@ project(idaxex)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)
 
-# Enable AES NI intrinsic
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -maes")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes")
+if(DEFINED ENV{IDASDK})
+  file(TO_CMAKE_PATH "$ENV{IDASDK}" _IDASDK_ROOT)
+  set(_IDASDK_BOOTSTRAP "")
+  if(EXISTS "${_IDASDK_ROOT}/src/cmake/bootstrap.cmake")
+    set(_IDASDK_BOOTSTRAP "${_IDASDK_ROOT}/src/cmake/bootstrap.cmake")
+  elseif(EXISTS "${_IDASDK_ROOT}/ida-cmake/bootstrap.cmake")
+    set(_IDASDK_BOOTSTRAP "${_IDASDK_ROOT}/ida-cmake/bootstrap.cmake")
+  endif()
 
-include($ENV{IDASDK}/ida-cmake/common.cmake)
+  if(NOT _IDASDK_BOOTSTRAP)
+    message(FATAL_ERROR "Could not find ida-cmake bootstrap under $ENV{IDASDK}")
+  endif()
 
-set(LOADER_NAME idaxex)
-set(LOADER_SOURCES
-  idaloader.cpp
-  idaloader_xbe.cpp
-  namegen.cpp
-  namegen_xtlid.cpp
-  formats/xbe.cpp
-  formats/xex.cpp
-  3rdparty/excrypt/src/excrypt_aes.c
-  3rdparty/excrypt/src/rijndael.c
-  3rdparty/excrypt/src/excrypt_sha.c
-  3rdparty/lzx.cpp
-  3rdparty/mspack/lzxd.c
-  3rdparty/mspack/system.c
-  3rdparty/XbSymbolDatabase/src/lib/libXbSymbolDatabase.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/D3D8_OOVPA.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/D3D8LTCG_OOVPA.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/DSound_OOVPA.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/JVS_OOVPA.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/XActEng_OOVPA.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/Xapi_OOVPA.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/XGraphic_OOVPA.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/XNet_OOVPA.c
-  3rdparty/XbSymbolDatabase/src/OOVPADatabase/XOnline_OOVPA.c
+  include("${_IDASDK_BOOTSTRAP}")
+  find_package(idasdk REQUIRED)
+else()
+  message(FATAL_ERROR "Set IDASDK to an IDA SDK root before configuring idaxex")
+endif()
+
+ida_add_loader(idaxex
+  SOURCES
+    idaloader.cpp
+    idaloader_xbe.cpp
+    namegen.cpp
+    namegen_xtlid.cpp
+    formats/xbe.cpp
+    formats/xex.cpp
+    3rdparty/excrypt/src/excrypt_aes.c
+    3rdparty/excrypt/src/rijndael.c
+    3rdparty/excrypt/src/excrypt_sha.c
+    3rdparty/lzx.cpp
+    3rdparty/mspack/lzxd.c
+    3rdparty/mspack/system.c
+    3rdparty/XbSymbolDatabase/src/lib/libXbSymbolDatabase.c
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase/D3D8_OOVPA.c
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase/D3D8LTCG_OOVPA.c
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase/DSound_OOVPA.c
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase/JVS_OOVPA.c
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase/XActEng_OOVPA.c
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase/Xapi_OOVPA.c
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase/XGraphic_OOVPA.c
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase/XNet_OOVPA.c
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase/XOnline_OOVPA.c
+  INCLUDES
+    3rdparty/excrypt/src
+    3rdparty/XbSymbolDatabase/include
+    3rdparty/XbSymbolDatabase/src/OOVPADatabase
+    ${_IDASDK_ROOT}/src/ldr/pe
+    ${_IDASDK_ROOT}/ldr/pe
+  DEFINES
+    IDALDR=1
 )
-set(LOADER_INCLUDE_DIRECTORIES 3rdparty/excrypt/src 3rdparty/XbSymbolDatabase/include 3rdparty/XbSymbolDatabase/src/OOVPADatabase $ENV{IDASDK}/ldr/pe)
-add_compile_definitions(IDALDR=1)
 
-generate()
-disable_ida_warnings(idaxex)
+target_compile_options(idaxex PRIVATE
+  $<$<AND:$<NOT:$<C_COMPILER_ID:MSVC>>,$<COMPILE_LANGUAGE:C>>:-maes>
+  $<$<AND:$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<COMPILE_LANGUAGE:CXX>>:-maes>
+  $<$<CXX_COMPILER_ID:Clang>:-Wno-non-pod-varargs>
+  $<$<CXX_COMPILER_ID:AppleClang>:-Wno-non-pod-varargs>
+)
+
+ida_disable_warnings(idaxex)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # idaxex
 
-idaxex is a native loader plugin for IDA Pro, adding support for loading in Xbox360 XEX & Xbox XBE executables.
+idaxex is a native loader plugin for IDA Pro 9.3, adding support for loading Xbox 360 XEX and Xbox XBE executables.
 
 Originally started as an [IDAPython loader](https://github.com/emoose/reversing/blob/master/xbox360.py), work was continued as a native DLL to solve the shortcomings of it.
 
@@ -33,11 +33,11 @@ Includes support for the following Xbox executables:
 - XBE: tries naming SDK library functions using [XbSymbolDatabase](https://github.com/Cxbx-Reloaded/XbSymbolDatabase) & data from XTLID section
 
 ## Install
-Builds for IDA 9 are available in the releases section.
+Prebuilt releases are available for supported IDA Pro 9.x versions.
 
-To install the loader just extract the contents of the folder for your IDA version into IDA's install folder (eg. C:\Program Files\IDA Professional 9.0\)
+Copy the loader files into the matching IDA installation's loader/plugin directory, or follow the build steps below and install the resulting binary into your IDA SDK output folder.
 
-I recommend pairing this loader with the PPCAltivec plugin, an updated version for IDA 7 is available at hayleyxyz's repo here: https://github.com/hayleyxyz/PPC-Altivec-IDA
+For PPC Altivec analysis, the PPCAltivec plugin remains a useful companion: https://github.com/hayleyxyz/PPC-Altivec-IDA
 
 ## Building
 
@@ -45,21 +45,22 @@ Make sure to clone repo recursively for excrypt submodule to get pulled in.
 
 **Windows**
 
-Clone the repo into your idasdk\ldr\ folder and then build idaxex.sln with VS2022.
+- Clone the repo with submodules enabled so the bundled crypto code is available.
+- Point `IDASDK` at your IDA SDK 9.3 root.
+- Use the SDK's CMake bootstrap or the generated Visual Studio project flow that comes with the SDK.
 
 **Linux**
 
-- Setup [ida-cmake](https://github.com/allthingsida/ida-cmake) in your idasdk folder
-- Make sure IDASDK env var points to your idasdk folder
-- Clone idaxex repo
-- Run `cmake . -DEA64=YES` inside idaxex folder
-- Run `make`
-- To build xex1tool run cmake/make inside the xex1tool folder
+- Use the IDA SDK 9.3 CMake bootstrap from `src/cmake/bootstrap.cmake` if your SDK tree has it, or the standalone [ida-cmake](https://github.com/allthingsida/ida-cmake) bootstrap if you keep that package separately.
+- Make sure `IDASDK` points at the SDK root.
+- Run `cmake -S . -B build` from the repo root.
+- Run `cmake --build build`.
+- To build `xex1tool`, run `cmake -S xex1tool -B xex1tool/build` and `cmake --build xex1tool/build`.
 
-On newest IDA you may need to edit ida-cmake common.cmake and change `libida64.so` to `libida.so` for build to link properly.
+On newer IDA SDKs, `libida.so` may be the correct library name in place of `libida64.so`.
 
 ## Credits
-Based on work by the Xenia project, XEX2.bt by Anthony, xextool 0.1 by xor37h, Xex Loader & x360_imports.idc by xorloser, xkelib, and probably many others I forgot to name.
+Based on work by the Xenia project, XEX2.bt by Anthony, xextool 0.1 by xor37h, Xex Loader & x360_imports.idc by xorloser, xkelib, XeCLI, and probably many others I forgot to name.
 
 Thanks to everyone involved in the Xbox 360 modding/reverse-engineering community!
 

--- a/idaloader.cpp
+++ b/idaloader.cpp
@@ -12,6 +12,7 @@
 #include <entry.hpp>
 #include <typeinf.hpp>
 #include <bytes.hpp>
+#include <segregs.hpp>
 
 struct exehdr {}; // needed for pe.h
 #include <pe.h>
@@ -104,6 +105,37 @@ void label_regsaveloads(ea_t start, ea_t end)
   }
 }
 
+static void file2base_patchable_clamped(linput_t* li, uint64_t file_offset, ea_t start_ea, ea_t end_ea, const char* what)
+{
+  if (end_ea <= start_ea)
+    return;
+
+  const uint64_t file_size = (uint64_t)qlsize(li);
+  if (file_offset >= file_size)
+  {
+    msg("[!] Skipping %s patch-back mapping at file offset 0x%llX: input file size is 0x%llX\n",
+      what, (unsigned long long)file_offset, (unsigned long long)file_size);
+    return;
+  }
+
+  uint64_t map_len = (uint64_t)(end_ea - start_ea);
+  const uint64_t available = file_size - file_offset;
+  if (map_len > available)
+  {
+    msg("[!] Clamping %s patch-back mapping at file offset 0x%llX from 0x%llX to 0x%llX bytes\n",
+      what,
+      (unsigned long long)file_offset,
+      (unsigned long long)map_len,
+      (unsigned long long)available);
+    map_len = available;
+  }
+
+  if (!map_len)
+    return;
+
+  file2base(li, file_offset, start_ea, start_ea + (ea_t)map_len, FILEREG_PATCHABLE);
+}
+
 void pe_add_sections(linput_t* li, XEXFile& file)
 {
   ignore_micro.init_ignore_micro();
@@ -157,12 +189,15 @@ void pe_add_sections(linput_t* li, XEXFile& file)
 
     const char* seg_class = has_code ? "CODE" : "DATA";
 
-    segment_t segm;
+    segment_t segm{};
     segm.start_ea = seg_addr;
     segm.end_ea = seg_addr + section.VirtualSize;
     segm.align = saRelDble;
     segm.bitness = 1;
     segm.perm = seg_perms;
+    segm.sel = allocate_selector(0);
+    for (int i = 0; i < SREG_NUM; i++)
+      segm.defsr[i] = BADSEL;
     add_segm_ex(&segm, name, seg_class, 0);
 
     // Load data into IDA
@@ -193,9 +228,19 @@ void pe_add_sections(linput_t* li, XEXFile& file)
   if (data_descriptor->DataFormat() == xex_opt::XexDataFormat::None)
   {
     // TODO: find a file to check this with (might be pre-XEX2 only...)
+    if (!first_segment_address)
+    {
+      msg("[!] Skipping patch-back mapping: no loadable bytes were added to the database\n");
+      return;
+    }
+
     auto first_segment_offset = first_segment_address - file.base_address();
     auto end_address = file.base_address() + file.image_size();
-    file2base(li, file.header().SizeOfHeaders + first_segment_offset, first_segment_address, end_address, FILEREG_PATCHABLE);
+    file2base_patchable_clamped(li,
+      uint64_t(file.header().SizeOfHeaders) + first_segment_offset,
+      first_segment_address,
+      end_address,
+      "raw");
     return;
   }
 
@@ -220,7 +265,11 @@ void pe_add_sections(linput_t* li, XEXFile& file)
       block_offset = first_segment_address - addr_start;
 
     if (addr_start + block_offset >= first_segment_address)
-      file2base(li, file.header().SizeOfHeaders + file_position + block_offset, addr_start + block_offset, addr_end, FILEREG_PATCHABLE);
+      file2base_patchable_clamped(li,
+        uint64_t(file.header().SizeOfHeaders) + file_position + block_offset,
+        addr_start + block_offset,
+        addr_end,
+        "block");
 
     address += block.DataSize + block.ZeroSize;
     file_position += block.DataSize;

--- a/idaloader_xbe.cpp
+++ b/idaloader_xbe.cpp
@@ -58,7 +58,7 @@ void xbe_add_sections(linput_t* li, XBEFile& file)
   add_segm_ex(&xbe_segm, "HEADER", "DATA", 0);
   mem2base(xbe_header.data(), xbe_segm.start_ea, xbe_segm.end_ea, -1);*/
 
-  sel_t ds = BADADDR;
+  sel_t ds = BADSEL;
 
   for (const auto& section : file.sections())
   {
@@ -88,7 +88,7 @@ void xbe_add_sections(linput_t* li, XBEFile& file)
     uint32 seg_addr = section.Info.VirtualAddress;
     size_t seg_size = section.DataSize;
 
-    segment_t segm;
+    segment_t segm{};
     segm.start_ea = seg_addr;
     segm.end_ea = seg_addr + section.Info.VirtualSize;
     segm.align = saRelByte;
@@ -96,7 +96,7 @@ void xbe_add_sections(linput_t* li, XBEFile& file)
     segm.perm = seg_perms;
     segm.sel = allocate_selector(0);
     for (int i = 0; i < SREG_NUM; i++)
-      segm.defsr[i] = BADADDR;
+      segm.defsr[i] = BADSEL;
 
     if (section.Name == ".data")
       ds = segm.sel;
@@ -108,7 +108,7 @@ void xbe_add_sections(linput_t* li, XBEFile& file)
       file2base(li, section.Info.PointerToRawData, seg_addr, seg_addr + seg_size, FILEREG_PATCHABLE);
   }
 
-  if (ds != BADADDR)
+  if (ds != BADSEL)
     set_default_dataseg(ds);
 }
 
@@ -249,19 +249,17 @@ bool xbe_scan_symboldb(XBEFile& file)
       ^ kXbeXorEntry_Retail;
   }
 
-  XbSDBLibraryHeader lib_header = {
-      .count = XbSDB_GenerateLibraryFilter(xbe_header, NULL),
-      .filters = (XbSDBLibrary*)malloc(lib_header.count * sizeof(XbSDBLibrary))
-  };
+  XbSDBLibraryHeader lib_header{};
+  lib_header.count = XbSDB_GenerateLibraryFilter(xbe_header, NULL);
+  lib_header.filters = (XbSDBLibrary*)malloc(lib_header.count * sizeof(XbSDBLibrary));
   if (!lib_header.filters) {
     return false;
   }
   XbSDB_GenerateLibraryFilter(xbe_header, &lib_header);
 
-  XbSDBSectionHeader sect_header = {
-      .count = XbSDB_GenerateSectionFilter(xbe_header, NULL, 1),
-      .filters = (XbSDBSection*)malloc(sect_header.count * sizeof(XbSDBSection))
-  };
+  XbSDBSectionHeader sect_header{};
+  sect_header.count = XbSDB_GenerateSectionFilter(xbe_header, NULL, 1);
+  sect_header.filters = (XbSDBSection*)malloc(sect_header.count * sizeof(XbSDBSection));
   if (!sect_header.filters) {
     free(lib_header.filters);
     return false;


### PR DESCRIPTION
I updated this to IDA Pro 9.3.

- Switched the build to the IDA SDK 9.3 bootstrap and loader helper.
- Hardened segment setup and patch-back mapping so the loader behaves correctly on newer SDKs.
- Updated the macOS byte-order include and refreshed the README build notes for IDA Pro 9.3.