### PR TITLE
Exclude ida-cmake Qt helpers from default VS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,26 @@ if(DEFINED ENV{IDASDK})
 
   include("${_IDASDK_BOOTSTRAP}")
   find_package(idasdk REQUIRED)
+
+  foreach(_IDAXEX_QT_HELPER_TARGET IN ITEMS
+      build_qt
+      qt6_external
+      qt6_external-download
+      qt6_external-configure
+      qt6_external-build
+      qt6_external-install
+    )
+    if(TARGET ${_IDAXEX_QT_HELPER_TARGET})
+      set_target_properties(${_IDAXEX_QT_HELPER_TARGET} PROPERTIES
+        EXCLUDE_FROM_ALL TRUE
+        EXCLUDE_FROM_DEFAULT_BUILD TRUE
+        EXCLUDE_FROM_DEFAULT_BUILD_DEBUG TRUE
+        EXCLUDE_FROM_DEFAULT_BUILD_RELEASE TRUE
+        EXCLUDE_FROM_DEFAULT_BUILD_RELWITHDEBINFO TRUE
+        EXCLUDE_FROM_DEFAULT_BUILD_MINSIZEREL TRUE
+      )
+    endif()
+  endforeach()
 else()
   message(FATAL_ERROR "Set IDASDK to an IDA SDK root before configuring idaxex")
 endif()


### PR DESCRIPTION
## Summary

- Exclude ida-cmake Qt helper targets from Visual Studio default solution builds.
- Covers `build_qt` plus the `qt6_external` step targets that ida-cmake creates.
- Keeps the explicit `build_qt` target available for users who intentionally want to build Qt.

## Verification

- Generated an actual `idaxex.sln` with Visual Studio 17 2022 / x64 using VS Community.
- CMake detected IDA SDK version `9.30`.
- Parsed the generated solution:
  - `QT_DEFAULT_BUILD_COUNT=0`
  - `DEFAULT_BUILD_PROJECTS=idaxex, ZERO_CHECK`
- Built the default solution with MSBuild Debug successfully.
- Confirmed no Qt download/configure/build/install target ran during the default build.